### PR TITLE
Fix column-wise scaling of componentwise statistics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pcadapt
 Type: Package
 Title: Fast Principal Component Analysis for Outlier Detection
-Version: 4.4.1
-Date: 2025-07-25
+Version: 4.4.2
+Date: 2026-09-08
 Authors@R: c(
     person("Keurcien", "Luu", role = "aut"), 
     person("Michael", "Blum", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## pcadapt 4.4.2
+
+- Fix GIF correction for `method = "componentwise"` (#100).
+
 ## pcadapt 4.4
 
 - Now derive a better estimate of the total variance, to get better estimates of the variance explained by each PC, especially when using clumping.

--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -215,7 +215,7 @@ get_statistics <- function(zscores, method, pass) {
     gif <- sapply(1:K, FUN = function(h) {
       median(zscores[, h]^2, na.rm = TRUE) / qchisq(0.5, df = 1)
     })
-    res.gif = res / gif
+    res.gif <- sweep(res, 2, gif, FUN = "/")
     pval <- NULL
     for (k in 1:K) {
       pval <- cbind(pval, pchisq(res.gif[, k], df = 1, lower.tail = FALSE))

--- a/tests/componentwise-scaling.R
+++ b/tests/componentwise-scaling.R
@@ -1,0 +1,32 @@
+library(pcadapt)
+
+get_statistics <- getFromNamespace("get_statistics", "pcadapt")
+
+check_scaling <- function(z) {
+  result <- get_statistics(z, method = "componentwise",
+                           pass = rep(TRUE, nrow(z)))
+  expected_gif <- apply(z^2, 2, median, na.rm = TRUE) / qchisq(.5, 1)
+  expected <- z^2
+  expected_p <- z^2
+  for (k in seq_len(ncol(z))) {
+    expected[, k] <- z[, k]^2 / expected_gif[k]
+    expected_p[, k] <- pchisq(expected[, k], 1, lower.tail = FALSE)
+  }
+  stopifnot(isTRUE(all.equal(unname(result$gif), unname(expected_gif))),
+            identical(dim(result$chi2.stat), dim(z)),
+            isTRUE(all.equal(unname(result$chi2.stat), unname(expected))),
+            isTRUE(all.equal(unname(result$pvalues), unname(expected_p))))
+  result
+}
+
+# Columns differing only by scale should have identical calibrated statistics.
+z <- cbind(PC1 = c(-2, -1, 1, 2), PC2 = c(-20, -10, 10, 20))
+result <- check_scaling(z)
+stopifnot(isTRUE(all.equal(result$chi2.stat[, 1], result$chi2.stat[, 2])))
+
+# Single component; row count not divisible by component count; missing values.
+invisible(check_scaling(z[, 1, drop = FALSE]))
+invisible(check_scaling(cbind(c(-2, -1, 1, 2, 3),
+                             c(-20, -10, 10, 20, 30))))
+z[1, ] <- NA_real_
+invisible(check_scaling(z))


### PR DESCRIPTION
## Summary

Fixes #100.

For `method = "componentwise"`, divide each column of squared z-scores by its corresponding genomic inflation factor using `sweep()`.

The previous expression, `res / gif`, recycles the vector through the matrix rather than applying one inflation factor per column. This can produce incorrect calibrated statistics and p-values when multiple components are used.

## Tests

Adds regression tests comparing statistics and p-values with explicit column-wise calculations, covering:

- Components with different scale factors.
- A single component.
- A row count not divisible by the number of components.
- Missing z-scores.

The tests pass against the corrected source and fail against the original calculation. A full package check has not been performed.

## Scope

This changes only the componentwise scaling calculation. The default Mahalanobis calculation is unchanged.