### PR TITLE
Fix componentwise Manhattan and Q-Q plots

### DIFF
--- a/R/plotUtils.R
+++ b/R/plotUtils.R
@@ -216,13 +216,16 @@ manhattan_plot = function(x, chr.info, snp.info, plt.pkg = "ggplot", K = 1) {
     if (K > attr(x, "K")) {
       stop(paste0("K can't exceed ", attr(x, "K")), ".")
     }
-    notNA.idx <- !is.na(x$pvalues[, K])
+    chi2.stat <- x$chi2.stat[, K]
+    degrees.freedom <- 1
   } else {
-    notNA.idx <- !is.na(x$pvalues)
+    chi2.stat <- x$chi2.stat
+    degrees.freedom <- attr(x, "K")
   }
+  notNA.idx <- !is.na(chi2.stat)
   
   df <- data.frame(x = which(notNA.idx), 
-                   y = -pchisq(x$chi2.stat[notNA.idx], df = attr(x, "K"),
+                   y = -pchisq(chi2.stat[notNA.idx], df = degrees.freedom,
                                lower.tail = FALSE, log.p = TRUE) / log(10))
   
   if (plt.pkg == "ggplot") {
@@ -301,12 +304,15 @@ qq_plot = function(x, K = 1) {
     if (K > attr(x, "K")) {
       stop(paste0("K can't exceed ", attr(x, "K")), ".")
     }
-    notNA.idx <- !is.na(x$pvalues[, K])
+    chi2.stat <- x$chi2.stat[, K]
+    degrees.freedom <- 1
   } else {
-    notNA.idx <- !is.na(x$pvalues)
+    chi2.stat <- x$chi2.stat
+    degrees.freedom <- attr(x, "K")
   }
+  notNA.idx <- !is.na(chi2.stat)
   
-  lpval <- -pchisq(x$chi2.stat[notNA.idx], df = attr(x, "K"),
+  lpval <- -pchisq(chi2.stat[notNA.idx], df = degrees.freedom,
                    lower.tail = FALSE, log.p = TRUE) / log(10)
   sorted.lpval <- sort(lpval, decreasing = TRUE)
   expected.p <- stats::ppoints(length(lpval))

--- a/tests/testthat/test_plot.R
+++ b/tests/testthat/test_plot.R
@@ -32,3 +32,43 @@ expect_s3_class(plot(x, option = "stat.distribution"), "ggplot")
 expect_s3_class(plot(x, option = "qqplot"), "ggplot")
 
 ################################################################################
+
+# Componentwise plots use the selected component and one degree of freedom.
+componentwise <- structure(
+  list(
+    chi2.stat = cbind(
+      c(1, NA, 4, 9),
+      c(16, 25, NA, 36)
+    ),
+    pvalues = cbind(
+      stats::pchisq(c(1, NA, 4, 9), df = 1, lower.tail = FALSE),
+      stats::pchisq(c(16, 25, NA, 36), df = 1, lower.tail = FALSE)
+    ),
+    maf = rep(0.25, 4)
+  ),
+  K = 2,
+  method = "componentwise",
+  min.maf = 0.05,
+  class = "pcadapt"
+)
+
+expected <- -stats::pchisq(
+  c(16, 25, 36),
+  df = 1,
+  lower.tail = FALSE,
+  log.p = TRUE
+) / log(10)
+
+manhattan <- pcadapt:::manhattan_plot(
+  componentwise,
+  chr.info = NULL,
+  snp.info = NULL,
+  K = 2
+)
+expect_equal(manhattan$data$x, c(1L, 2L, 4L))
+expect_equal(manhattan$data$y, expected)
+
+qq <- pcadapt:::qq_plot(componentwise, K = 2)
+expect_equal(sort(qq$data$y), sort(expected))
+
+################################################################################


### PR DESCRIPTION
## Summary

This fixes the Manhattan and Q–Q plots produced for
`method = "componentwise"`.

Previously, the functions identified non-missing markers from the selected
component but then subset the full `chi2.stat` matrix using one-dimensional
indexing. R consequently indexed the matrix as a flattened vector, so a plot
requested for PC2 or a later component could display statistics from another
component.

The plotted probabilities were also calculated using `K` degrees of freedom.
Each componentwise squared z-score follows a chi-squared distribution with one
degree of freedom.

## Changes

- Explicitly select `chi2.stat[, K]` for componentwise plots.
- Use one degree of freedom for the componentwise chi-squared distribution.
- Preserve `K` degrees of freedom for the Mahalanobis statistic.
- Determine retained markers from the selected statistic vector.
- Add regression tests for PC2, including component-specific missing values.
- Verify both Manhattan and Q–Q plot values against their expected
  probabilities.

## Validation

- `devtools::test()`: 41 passed, 0 failed.
- `R CMD check`: 0 errors, 0 warnings, 0 notes.

This PR is independent of #101. That PR corrects componentwise genomic
inflation scaling, whereas this PR corrects selection and interpretation of
the component used by the plotting functions.