### PR TITLE
Validate matrix genotype hard calls before integer conversion

### DIFF
--- a/R/pcadaptRead.R
+++ b/R/pcadaptRead.R
@@ -8,8 +8,10 @@
 #'   For a matrix as input, this returns a matrix. 
 #'
 #' @param input A genotype matrix or a character string specifying the name of 
-#'   the file to be converted. Matrices should use NAs to encode missing values. 
-#'   To encode missing values in 'pcadapt' and 'lfmm' files, 9s should be used.
+#'   the file to be converted. Genotype matrices must contain hard calls coded
+#'   as 0, 1, or 2, with \code{NA} for missing values. Pool-seq matrices must
+#'   contain allele frequencies. To encode missing values in 'pcadapt' and
+#'   'lfmm' files, 9s should be used.
 #' @param type A character string specifying the type of data to be converted 
 #'   from. Converters from 'vcf' and 'ped' formats are not maintained anymore;
 #'   if you have any issue with those, please use PLINK >= 1.9 to convert them
@@ -129,6 +131,27 @@ matrix2other <- function(input, type.in) {
     return(structure(as.matrix(input), class = "pcadapt_pool"))
   } else {
     stop("Incorrect type.in for matrices.")
+  }
+
+  if (!is.numeric(res) && !is.logical(res)) {
+    stop(paste(
+      "Genotype matrices must contain numeric hard calls coded as",
+      "0, 1, or 2, with NA for missing values."
+    ))
+  }
+
+  if (any(is.nan(res))) {
+    stop("NaN is not a valid missing genotype; use NA instead.")
+  }
+
+  observed <- res[!is.na(res)]
+  if (any(!is.finite(observed)) ||
+      any(observed != floor(observed)) ||
+      any(!observed %in% 0:2)) {
+    stop(paste(
+      "Genotype matrices must contain hard calls coded as",
+      "0, 1, or 2, with NA for missing values."
+    ))
   }
   
   if (nrow(res) > ncol(res)) {

--- a/man/read.pcadapt.Rd
+++ b/man/read.pcadapt.Rd
@@ -17,8 +17,10 @@ read.pcadapt(
 }
 \arguments{
 \item{input}{A genotype matrix or a character string specifying the name of 
-the file to be converted. Matrices should use NAs to encode missing values. 
-To encode missing values in 'pcadapt' and 'lfmm' files, 9s should be used.}
+the file to be converted. Genotype matrices must contain hard calls coded
+as 0, 1, or 2, with \code{NA} for missing values. Pool-seq matrices must
+contain allele frequencies. To encode missing values in 'pcadapt' and
+'lfmm' files, 9s should be used.}
 
 \item{type}{A character string specifying the type of data to be converted 
 from. Converters from 'vcf' and 'ped' formats are not maintained anymore;

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -21,11 +21,37 @@ input <- file.copy(lfmm, tmp <- tempfile(fileext = ".lfmm"))
 
 ################################################################################
 
+# Matrix hard-call validation
+valid <- matrix(c(0, 1, 2, NA), nrow = 2)
+valid.input <- read.pcadapt(valid, type = "pcadapt")
+expect_s3_class(valid.input, "pcadapt_matrix")
+expect_type(valid.input, "integer")
+expect_equal(unclass(valid.input), t(valid), check.attributes = FALSE)
 
-################################################################################
-
-
-################################################################################
-
+expect_error(
+  read.pcadapt(matrix(c(0, 1.9, 2, NA), nrow = 2), type = "pcadapt"),
+  "hard calls coded as 0, 1, or 2",
+  fixed = TRUE
+)
+expect_error(
+  read.pcadapt(matrix(c(0, 1, 3, NA), nrow = 2), type = "pcadapt"),
+  "hard calls coded as 0, 1, or 2",
+  fixed = TRUE
+)
+expect_error(
+  read.pcadapt(matrix(c(0, 1, Inf, NA), nrow = 2), type = "pcadapt"),
+  "hard calls coded as 0, 1, or 2",
+  fixed = TRUE
+)
+expect_error(
+  read.pcadapt(matrix(c(0, 1, NaN, NA), nrow = 2), type = "pcadapt"),
+  "NaN is not a valid missing genotype",
+  fixed = TRUE
+)
+expect_error(
+  read.pcadapt(matrix(c("0", "1", "2", NA), nrow = 2), type = "pcadapt"),
+  "numeric hard calls",
+  fixed = TRUE
+)
 
 ################################################################################


### PR DESCRIPTION
## Summary

This prevents `read.pcadapt()` from silently converting continuous allele
dosages or invalid matrix values into integer genotype calls.

The matrix pathway currently expects hard genotypes coded as `0`, `1`, or `2`.
However, it previously converted matrices using:

```r
storage.mode(res) <- "integer"
```

without first validating their contents. This can silently change the
biological interpretation of valid continuous data. For example, an imputed
allele dosage of `1.9` is truncated to `1`, converting evidence close to two
alternate alleles into a heterozygous hard call.

Continuous allele dosages are valid genomic data, but they are not supported
by this hard-call input pathway and should not be converted implicitly.

## Changes

For matrix input with `type = "pcadapt"` or `type = "lfmm"`:

- Require numeric or logical data.
- Accept hard genotype calls coded as `0`, `1`, or `2`.
- Continue to accept `NA` as a missing genotype.
- Reject continuous or fractional dosages.
- Reject values outside `0:2`.
- Reject infinite values.
- Reject `NaN` with guidance to use `NA` for missing calls.
- Reject character matrices rather than coercing them silently.
- Document the required matrix encoding.

Pool-seq matrices are intentionally unaffected because they contain allele
frequencies rather than hard genotype calls and require separate validation
rules.

## Why this matters

Allele dosages are commonly represented by continuous values between zero and
two. For example, an expected alternate-allele dosage can be written as:

> **E(G | data) = P(G = 1 | data) + 2 × P(G = 2 | data)**

Here, `G` is the unobserved hard genotype and `E(G | data)` is its expected
alternate-allele dosage given the available data.

Such a dosage should not be truncated and treated as an observed hard call.
Rejecting unsupported continuous values allows users to choose and document an
appropriate hard-calling procedure, or to use a method designed to analyse
genotype uncertainty or continuous dosages.

## Tests

Regression tests cover:

- Valid `0/1/2/NA` input.
- Continuous allele dosages.
- Out-of-range calls.
- Infinite values.
- `NaN`.
- Character matrices.

Validation results:

- `devtools::test()`: 46 passed, 0 failed.
- `R CMD check`: 0 errors, 0 warnings, 0 notes.