### PR TITLE
Validate PCA parameters and rank after marker filtering

### DIFF
--- a/R/iram.R
+++ b/R/iram.R
@@ -22,9 +22,6 @@ iram_and_reg <- function(input, K, min.maf, ploidy, LD.clumping, tol) {
   n <- dim(input)[1]  ## can't use nrow()
   p <- dim(input)[2]  ## can't use ncol()
   
-  if (K > min(n, p))
-    stop(call. = FALSE, "You cannot have K larger than any of the dimensions.")
-  
   # Get allele frequencies
   # Uses a non-scaled lookup table
   af <- get_af(input) / ploidy
@@ -50,9 +47,34 @@ iram_and_reg <- function(input, K, min.maf, ploidy, LD.clumping, tol) {
     ind.pass <- ind.pass.af
   }
   p2 <- length(ind.pass)
+
+  if (p2 == 0L) {
+    stop(
+      "No markers remain after minor-allele-frequency filtering and LD clumping.",
+      call. = FALSE
+    )
+  }
+
+  if (K >= min(n, p2)) {
+    stop(
+      paste0(
+        "K must be smaller than both the number of individuals and the number ",
+        "of retained markers (", n, " individuals; ", p2,
+        " retained markers)."
+      ),
+      call. = FALSE
+    )
+  }
   
   # Get number of non-missing values per row and per column
   nb_nona <- nb_nona(input, ind.pass)
+
+  if (any(nb_nona$p == 0)) {
+    stop(
+      "At least one individual has no called genotypes among the retained markers.",
+      call. = FALSE
+    )
+  }
   
   ### SVD using RSpectra
   tryCatch(

--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -35,7 +35,9 @@ NULL
 #' distance for each SNP.
 #'
 #' @param input The output of function \code{read.pcadapt}.
-#' @param K an integer specifying the number of principal components to retain.
+#' @param K A positive integer specifying the number of principal components to
+#'   retain. It must be smaller than both the number of individuals and the
+#'   number of markers retained after filtering and LD clumping.
 #' @param method a character string specifying the method to be used to compute
 #'   the p-values. Two statistics are currently available, \code{"mahalanobis"},
 #'   and \code{"componentwise"}.
@@ -48,8 +50,9 @@ NULL
 #'   be \code{list(size = 500, thr = 0.1)}.
 #' @param pca.only a logical value indicating whether PCA results should be 
 #'   returned (before computing any statistic).
-#' @param ploidy Number of trials, parameter of the binomial distribution. 
-#'   Default is 2, which corresponds to diploidy, such as for the human genome.
+#' @param ploidy For genotype input, a positive integer giving the number of
+#'   chromosome copies. Default is 2, which corresponds to diploidy, such as
+#'   for the human genome. This argument is not used for Pool-seq input.
 #' @param tol Convergence criterion of \code{RSpectra::svds()}. 
 #'   Default is \code{1e-4}.
 #' 
@@ -229,11 +232,51 @@ get_statistics <- function(zscores, method, pass) {
 pcadapt0 <- function(input, K, method, min.maf, ploidy, LD.clumping, pca.only, tol) {
   
   # Test arguments and init
-  if (!(class(K) %in% c("numeric", "integer")) || K <= 0)
-    stop("K has to be a positive integer.")
+  if (!is.numeric(K) || length(K) != 1L || is.na(K) ||
+      !is.finite(K) || K <= 0 || K != floor(K)) {
+    stop("K must be one positive integer.", call. = FALSE)
+  }
   
-  if (!is.numeric(min.maf) || min.maf < 0 || min.maf > 0.45) 
-    stop("min.maf has to be a real number between 0 and 0.45.")
+  if (!is.numeric(min.maf) || length(min.maf) != 1L || is.na(min.maf) ||
+      !is.finite(min.maf) || min.maf < 0 || min.maf > 0.45) {
+    stop("min.maf must be one finite number between 0 and 0.45.",
+         call. = FALSE)
+  }
+
+  if (!is.numeric(ploidy) || length(ploidy) != 1L || is.na(ploidy) ||
+      !is.finite(ploidy) || ploidy <= 0 || ploidy != floor(ploidy)) {
+    stop("ploidy must be one positive integer.", call. = FALSE)
+  }
+
+  if (!is.logical(pca.only) || length(pca.only) != 1L || is.na(pca.only)) {
+    stop("pca.only must be TRUE or FALSE.", call. = FALSE)
+  }
+
+  if (!is.numeric(tol) || length(tol) != 1L || is.na(tol) ||
+      !is.finite(tol) || tol <= 0) {
+    stop("tol must be one positive finite number.", call. = FALSE)
+  }
+
+  if (!is.null(LD.clumping)) {
+    if (!is.list(LD.clumping) || is.null(LD.clumping$size) ||
+        is.null(LD.clumping$thr)) {
+      stop("LD.clumping must be NULL or a list containing size and thr.",
+           call. = FALSE)
+    }
+
+    size <- LD.clumping$size
+    if (!is.numeric(size) || length(size) != 1L || is.na(size) ||
+        !is.finite(size) || size <= 0 || size != floor(size)) {
+      stop("LD.clumping$size must be one positive integer.", call. = FALSE)
+    }
+
+    thr <- LD.clumping$thr
+    if (!is.numeric(thr) || length(thr) != 1L || is.na(thr) ||
+        !is.finite(thr) || thr < 0 || thr > 1) {
+      stop("LD.clumping$thr must be one finite number between 0 and 1.",
+           call. = FALSE)
+    }
+  }
   
   # Compute PCs and z-scores    
   obj.pca <- iram_and_reg(input, K = K, 

--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -50,9 +50,9 @@ NULL
 #'   be \code{list(size = 500, thr = 0.1)}.
 #' @param pca.only a logical value indicating whether PCA results should be 
 #'   returned (before computing any statistic).
-#' @param ploidy For genotype input, a positive integer giving the number of
-#'   chromosome copies. Default is 2, which corresponds to diploidy, such as
-#'   for the human genome. This argument is not used for Pool-seq input.
+#' @param ploidy For genotype input, either code{1} for haploid dosage data or
+#'   code{2} for diploid dosage data. Default is code{2}. Polyploid genotype
+#'   dosages are not supported. This argument is not used for Pool-seq input.
 #' @param tol Convergence criterion of \code{RSpectra::svds()}. 
 #'   Default is \code{1e-4}.
 #' 
@@ -244,8 +244,8 @@ pcadapt0 <- function(input, K, method, min.maf, ploidy, LD.clumping, pca.only, t
   }
 
   if (!is.numeric(ploidy) || length(ploidy) != 1L || is.na(ploidy) ||
-      !is.finite(ploidy) || ploidy <= 0 || ploidy != floor(ploidy)) {
-    stop("ploidy must be one positive integer.", call. = FALSE)
+      !is.finite(ploidy) || !(ploidy %in% c(1, 2))) {
+    stop("ploidy must be either 1 (haploid) or 2 (diploid).", call. = FALSE)
   }
 
   if (!is.logical(pca.only) || length(pca.only) != 1L || is.na(pca.only)) {

--- a/man/pcadapt.Rd
+++ b/man/pcadapt.Rd
@@ -54,7 +54,9 @@ pcadapt(
 \arguments{
 \item{input}{The output of function \code{read.pcadapt}.}
 
-\item{K}{an integer specifying the number of principal components to retain.}
+\item{K}{A positive integer specifying the number of principal components to
+retain. It must be smaller than both the number of individuals and the
+number of markers retained after filtering and LD clumping.}
 
 \item{method}{a character string specifying the method to be used to compute
 the p-values. Two statistics are currently available, \code{"mahalanobis"},
@@ -63,8 +65,9 @@ and \code{"componentwise"}.}
 \item{min.maf}{Threshold of minor allele frequencies above which p-values are 
 computed. Default is \code{0.05}.}
 
-\item{ploidy}{Number of trials, parameter of the binomial distribution. 
-Default is 2, which corresponds to diploidy, such as for the human genome.}
+\item{ploidy}{For genotype input, a positive integer giving the number of
+chromosome copies. Default is 2, which corresponds to diploidy, such as
+for the human genome. This argument is not used for Pool-seq input.}
 
 \item{LD.clumping}{Default is \code{NULL} and doesn't use any SNP thinning.
 If you want to use SNP thinning, provide a named list with parameters 

--- a/man/pcadapt.Rd
+++ b/man/pcadapt.Rd
@@ -65,9 +65,9 @@ and \code{"componentwise"}.}
 \item{min.maf}{Threshold of minor allele frequencies above which p-values are 
 computed. Default is \code{0.05}.}
 
-\item{ploidy}{For genotype input, a positive integer giving the number of
-chromosome copies. Default is 2, which corresponds to diploidy, such as
-for the human genome. This argument is not used for Pool-seq input.}
+\item{ploidy}{For genotype input, either \code{1} for haploid dosage data or
+\code{2} for diploid dosage data. Default is \code{2}. Polyploid genotype
+dosages are not supported. This argument is not used for Pool-seq input.}
 
 \item{LD.clumping}{Default is \code{NULL} and doesn't use any SNP thinning.
 If you want to use SNP thinning, provide a named list with parameters 

--- a/tests/testthat/test_validation.R
+++ b/tests/testthat/test_validation.R
@@ -18,9 +18,11 @@ expect_error(pcadapt(geno, K = 0), "one positive integer", fixed = TRUE)
 expect_error(pcadapt(geno, K = 2, min.maf = NA_real_),
              "one finite number", fixed = TRUE)
 expect_error(pcadapt(geno, K = 2, ploidy = 0),
-             "one positive integer", fixed = TRUE)
+             "either 1 (haploid) or 2 (diploid)", fixed = TRUE)
 expect_error(pcadapt(geno, K = 2, ploidy = 1.5),
-             "one positive integer", fixed = TRUE)
+             "either 1 (haploid) or 2 (diploid)", fixed = TRUE)
+expect_error(pcadapt(geno, K = 2, ploidy = 3),
+             "either 1 (haploid) or 2 (diploid)", fixed = TRUE)
 expect_error(pcadapt(geno, K = 2, pca.only = NA),
              "TRUE or FALSE", fixed = TRUE)
 expect_error(pcadapt(geno, K = 2, tol = 0),

--- a/tests/testthat/test_validation.R
+++ b/tests/testthat/test_validation.R
@@ -1,0 +1,72 @@
+################################################################################
+
+context("VALIDATION")
+
+################################################################################
+
+set.seed(1)
+geno <- matrix(rbinom(20 * 30, size = 2, prob = 0.3), nrow = 20)
+class(geno) <- c("pcadapt_matrix", "matrix", "array")
+
+# Scalar analysis arguments
+expect_error(pcadapt(geno, K = 1.5), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(geno, K = c(1, 2)), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(geno, K = NA_real_), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(geno, K = Inf), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(geno, K = 0), "one positive integer", fixed = TRUE)
+
+expect_error(pcadapt(geno, K = 2, min.maf = NA_real_),
+             "one finite number", fixed = TRUE)
+expect_error(pcadapt(geno, K = 2, ploidy = 0),
+             "one positive integer", fixed = TRUE)
+expect_error(pcadapt(geno, K = 2, ploidy = 1.5),
+             "one positive integer", fixed = TRUE)
+expect_error(pcadapt(geno, K = 2, pca.only = NA),
+             "TRUE or FALSE", fixed = TRUE)
+expect_error(pcadapt(geno, K = 2, tol = 0),
+             "positive finite number", fixed = TRUE)
+
+# LD-clumping arguments
+expect_error(
+  pcadapt(geno, K = 2, LD.clumping = list(size = 10)),
+  "containing size and thr",
+  fixed = TRUE
+)
+expect_error(
+  pcadapt(geno, K = 2, LD.clumping = list(size = 1.5, thr = 0.2)),
+  "size must be one positive integer",
+  fixed = TRUE
+)
+expect_error(
+  pcadapt(geno, K = 2, LD.clumping = list(size = 10, thr = 1.1)),
+  "thr must be one finite number between 0 and 1",
+  fixed = TRUE
+)
+
+# Rank after marker filtering
+few.variable <- matrix(0L, nrow = 20, ncol = 10)
+few.variable[, 1] <- rep(c(0L, 1L), each = 10)
+few.variable[, 2] <- rep(c(1L, 2L), each = 10)
+class(few.variable) <- c("pcadapt_matrix", "matrix", "array")
+
+expect_error(
+  pcadapt(few.variable, K = 2),
+  "2 retained markers",
+  fixed = TRUE
+)
+expect_error(
+  pcadapt(few.variable, K = 1, min.maf = 0.45),
+  "No markers remain",
+  fixed = TRUE
+)
+
+# Individuals without retained genotype calls
+missing.individual <- geno
+missing.individual[1, ] <- NA_integer_
+expect_error(
+  pcadapt(missing.individual, K = 2),
+  "individual has no called genotypes",
+  fixed = TRUE
+)
+
+################################################################################


### PR DESCRIPTION
## Summary

This adds explicit validation for genotype-based `pcadapt()` analyses and
checks that the requested number of principal components remains feasible
after minor-allele-frequency filtering and LD clumping.

Some invalid arguments previously reached the C++ or SVD implementation,
producing ambiguous errors or internally inconsistent results. For example,
a fractional value such as `K = 1.5` was accepted: one component was computed,
while the returned object retained `K = 1.5`.

A more realistic problem occurs when `K` is valid for the original matrix but
too large for the number of markers retained after filtering or LD clumping.
This was previously reported as a generic SVD failure.

## Changes

The genotype-based analysis now requires:

- `K` to be one positive integer.
- `min.maf` to be one finite number between 0 and 0.45.
- `ploidy` to be one positive integer.
- `pca.only` to be either `TRUE` or `FALSE`.
- `tol` to be one positive finite number.
- `LD.clumping` to be `NULL` or a list containing `size` and `thr`.
- `LD.clumping$size` to be one positive integer.
- `LD.clumping$thr` to be one finite number between zero and one.

After MAF filtering and LD clumping, the analysis now:

- Stops clearly when no markers remain.
- Requires `K` to be smaller than both the number of individuals and the
  number of retained markers.
- Reports the relevant dimensions when the requested rank is infeasible.
- Stops clearly when an individual has no called genotypes among the retained
  markers.

## Why this matters

The parameter checks primarily improve defensive behaviour and error
reporting. Values such as fractional `K` or zero ploidy are invalid inputs, but
they should be rejected before reaching numerical code.

The retained-rank check addresses an ordinary analytical situation. MAF
filtering or LD clumping can substantially reduce the number of available
markers, meaning a previously plausible `K` may no longer define a valid
truncated singular-value decomposition.

These checks do not change results for valid analyses.

## Documentation

The documentation now states that:

- `K` must be a positive integer smaller than the relevant retained
  dimensions.
- For genotype data, `ploidy` must be a positive integer.
- `ploidy` is not used for Pool-seq input.

Pool-seq-specific validation is intentionally reserved for a separate change.

## Tests

Regression tests cover:

- Fractional, vector-valued, missing, infinite, zero, and negative `K`.
- Missing MAF thresholds.
- Invalid ploidy.
- Invalid `pca.only` and SVD tolerance values.
- Missing and malformed LD-clumping settings.
- Insufficient rank after marker filtering.
- Removal of all markers.
- Individuals without called genotypes among retained markers.

Validation results:

- `devtools::test()`: 54 passed, 0 failed.
- `R CMD check`: 0 errors, 0 warnings, 0 notes.