### PR TITLE
Validate Pool-seq inputs and retained PCA rank

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 - Now derive a better estimate of the total variance, to get better estimates of the variance explained by each PC, especially when using clumping.
 
+- Validate Pool-seq frequency matrices and analysis parameters, and report
+  unsupported options instead of silently ignoring them.
+
 ## pcadapt 4.0
 
 - `read.pcadapt()` generates `bed` files instead of `pcadapt` files.

--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -34,8 +34,12 @@ NULL
 #' Pool-seq data, \code{pcadapt} provides p-values based on the Mahalanobis 
 #' distance for each SNP.
 #'
-#' @param input The output of function \code{read.pcadapt}.
-#' @param K an integer specifying the number of principal components to retain.
+#' @param input The output of function \code{read.pcadapt}. Pool-seq input must
+#'   be a numeric matrix with pools in rows, markers in columns, allele
+#'   frequencies between zero and one, and \code{NA} for missing frequencies.
+#' @param K A positive integer specifying the number of principal components to
+#'   retain. For Pool-seq data, it cannot exceed the smaller of the number of
+#'   pools minus one and the number of markers retained after MAF filtering.
 #' @param method a character string specifying the method to be used to compute
 #'   the p-values. Two statistics are currently available, \code{"mahalanobis"},
 #'   and \code{"componentwise"}.
@@ -45,11 +49,13 @@ NULL
 #'   If you want to use SNP thinning, provide a named list with parameters 
 #'   \code{$size} and \code{$thr} which corresponds respectively to the window 
 #'   radius and the squared correlation threshold. A good default value would 
-#'   be \code{list(size = 500, thr = 0.1)}.
+#'   be \code{list(size = 500, thr = 0.1)}. LD clumping is not implemented for
+#'   Pool-seq input.
 #' @param pca.only a logical value indicating whether PCA results should be 
 #'   returned (before computing any statistic).
 #' @param ploidy Number of trials, parameter of the binomial distribution. 
 #'   Default is 2, which corresponds to diploidy, such as for the human genome.
+#'   This argument is not used for Pool-seq input and must then be \code{NULL}.
 #' @param tol Convergence criterion of \code{RSpectra::svds()}. 
 #'   Default is \code{1e-4}.
 #' 
@@ -128,8 +134,68 @@ pcadapt.pcadapt_pool <- function(input,
                                  LD.clumping = NULL,
                                  pca.only = FALSE,
                                  tol) {
-  
-  w <- matrix(NA_real_, nrow = ncol(input), ncol = K)
+
+  if (!is.matrix(input) || !is.numeric(input)) {
+    stop("Pool-seq input must be a numeric matrix.", call. = FALSE)
+  }
+
+  if (nrow(input) < 2L || ncol(input) < 1L) {
+    stop(
+      "Pool-seq input must contain at least two pools and one marker.",
+      call. = FALSE
+    )
+  }
+
+  if (any(is.nan(input))) {
+    stop("NaN is not a valid missing frequency; use NA instead.", call. = FALSE)
+  }
+
+  observed <- input[!is.na(input)]
+  if (any(!is.finite(observed)) || any(observed < 0 | observed > 1)) {
+    stop(
+      "Pool-seq allele frequencies must be finite values between 0 and 1.",
+      call. = FALSE
+    )
+  }
+
+  if (any(colSums(!is.na(input)) == 0L)) {
+    stop("Each Pool-seq marker must have at least one observed frequency.",
+         call. = FALSE)
+  }
+
+  if (any(rowSums(!is.na(input)) == 0L)) {
+    stop("Each pool must have at least one observed marker frequency.",
+         call. = FALSE)
+  }
+
+  if (!is.numeric(K) || length(K) != 1L || is.na(K) ||
+      !is.finite(K) || K <= 0 || K != floor(K)) {
+    stop("K must be one positive integer.", call. = FALSE)
+  }
+
+  if (!is.character(method) || length(method) != 1L || is.na(method) ||
+      !method %in% c("mahalanobis", "componentwise")) {
+    stop("method must be 'mahalanobis' or 'componentwise'.", call. = FALSE)
+  }
+
+  if (!is.numeric(min.maf) || length(min.maf) != 1L || is.na(min.maf) ||
+      !is.finite(min.maf) || min.maf < 0 || min.maf > 0.45) {
+    stop("min.maf must be one finite number between 0 and 0.45.",
+         call. = FALSE)
+  }
+
+  if (!is.null(ploidy)) {
+    stop("ploidy is not used for Pool-seq input and must be NULL.",
+         call. = FALSE)
+  }
+
+  if (!is.null(LD.clumping)) {
+    stop("LD.clumping is not implemented for Pool-seq input.", call. = FALSE)
+  }
+
+  if (!is.logical(pca.only) || length(pca.only) != 1L || is.na(pca.only)) {
+    stop("pca.only must be TRUE or FALSE.", call. = FALSE)
+  }
   
   tmat <- scale(input, center = TRUE, scale = FALSE) 
   tmat[is.na(tmat)] <- 0 # mean imputation
@@ -137,7 +203,26 @@ pcadapt.pcadapt_pool <- function(input,
   mean_freq <- attr(tmat, "scaled:center")
   mean_freq <- pmin(mean_freq, 1 - mean_freq)
 
-  pass <- mean_freq > min.maf
+  pass <- mean_freq >= min.maf
+
+  n.retained <- sum(pass)
+  if (n.retained == 0L) {
+    stop("No Pool-seq markers remain after MAF filtering.", call. = FALSE)
+  }
+
+  max.rank <- min(nrow(input) - 1L, n.retained)
+  if (K > max.rank) {
+    stop(
+      paste0(
+        "For Pool-seq input, K cannot exceed ", max.rank,
+        " with ", nrow(input), " pools and ", n.retained,
+        " retained markers."
+      ),
+      call. = FALSE
+    )
+  }
+
+  w <- matrix(NA_real_, nrow = ncol(input), ncol = K)
   
   if (nrow(input) == 2) {
     obj.pca <- list(

--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -51,13 +51,15 @@ NULL
 #'   radius and the squared correlation threshold. A good default value would 
 #'   be \code{list(size = 500, thr = 0.1)}. LD clumping is not implemented for
 #'   Pool-seq input.
-#' @param pca.only a logical value indicating whether PCA results should be 
-#'   returned (before computing any statistic).
+#' @param pca.only a logical value indicating whether PCA results should be
+#'   returned before computing any statistic. This option is not implemented
+#'   for Pool-seq input and must then be \code{FALSE}.
 #' @param ploidy Number of trials, parameter of the binomial distribution. 
 #'   Default is 2, which corresponds to diploidy, such as for the human genome.
 #'   This argument is not used for Pool-seq input and must then be \code{NULL}.
-#' @param tol Convergence criterion of \code{RSpectra::svds()}. 
-#'   Default is \code{1e-4}.
+#' @param tol Convergence criterion of \code{RSpectra::svds()} for genotype
+#'   input. Pool-seq analysis currently uses \code{base::svd()}, so this
+#'   argument must not be supplied for Pool-seq input. Default is \code{1e-4}.
 #' 
 #' @return The returned value is an object of class \code{pcadapt}.
 #' 
@@ -195,6 +197,17 @@ pcadapt.pcadapt_pool <- function(input,
 
   if (!is.logical(pca.only) || length(pca.only) != 1L || is.na(pca.only)) {
     stop("pca.only must be TRUE or FALSE.", call. = FALSE)
+  }
+
+  if (pca.only) {
+    stop("pca.only is not implemented for Pool-seq input.", call. = FALSE)
+  }
+
+  if (!missing(tol)) {
+    stop(
+      "tol is not used for Pool-seq input, which uses base::svd().",
+      call. = FALSE
+    )
   }
   
   tmat <- scale(input, center = TRUE, scale = FALSE) 

--- a/man/pcadapt.Rd
+++ b/man/pcadapt.Rd
@@ -78,11 +78,13 @@ radius and the squared correlation threshold. A good default value would
 be \code{list(size = 500, thr = 0.1)}. LD clumping is not implemented for
 Pool-seq input.}
 
-\item{pca.only}{a logical value indicating whether PCA results should be 
-returned (before computing any statistic).}
+\item{pca.only}{a logical value indicating whether PCA results should be
+returned before computing any statistic. This option is not implemented
+for Pool-seq input and must then be \code{FALSE}.}
 
-\item{tol}{Convergence criterion of \code{RSpectra::svds()}. 
-Default is \code{1e-4}.}
+\item{tol}{Convergence criterion of \code{RSpectra::svds()} for genotype
+input. Pool-seq analysis currently uses \code{base::svd()}, so this
+argument must not be supplied for Pool-seq input. Default is \code{1e-4}.}
 }
 \value{
 The returned value is an object of class \code{pcadapt}.

--- a/man/pcadapt.Rd
+++ b/man/pcadapt.Rd
@@ -52,9 +52,13 @@ pcadapt(
 )
 }
 \arguments{
-\item{input}{The output of function \code{read.pcadapt}.}
+\item{input}{The output of function \code{read.pcadapt}. Pool-seq input must
+be a numeric matrix with pools in rows, markers in columns, allele
+frequencies between zero and one, and \code{NA} for missing frequencies.}
 
-\item{K}{an integer specifying the number of principal components to retain.}
+\item{K}{A positive integer specifying the number of principal components to
+retain. For Pool-seq data, it cannot exceed the smaller of the number of
+pools minus one and the number of markers retained after MAF filtering.}
 
 \item{method}{a character string specifying the method to be used to compute
 the p-values. Two statistics are currently available, \code{"mahalanobis"},
@@ -64,13 +68,15 @@ and \code{"componentwise"}.}
 computed. Default is \code{0.05}.}
 
 \item{ploidy}{Number of trials, parameter of the binomial distribution. 
-Default is 2, which corresponds to diploidy, such as for the human genome.}
+Default is 2, which corresponds to diploidy, such as for the human genome.
+This argument is not used for Pool-seq input and must then be \code{NULL}.}
 
 \item{LD.clumping}{Default is \code{NULL} and doesn't use any SNP thinning.
 If you want to use SNP thinning, provide a named list with parameters 
 \code{$size} and \code{$thr} which corresponds respectively to the window 
 radius and the squared correlation threshold. A good default value would 
-be \code{list(size = 500, thr = 0.1)}.}
+be \code{list(size = 500, thr = 0.1)}. LD clumping is not implemented for
+Pool-seq input.}
 
 \item{pca.only}{a logical value indicating whether PCA results should be 
 returned (before computing any statistic).}

--- a/tests/testthat/test_pool_validation.R
+++ b/tests/testthat/test_pool_validation.R
@@ -1,0 +1,78 @@
+################################################################################
+
+context("POOLSEQ_VALIDATION")
+
+################################################################################
+
+set.seed(1)
+pool <- matrix(stats::runif(4 * 20, min = 0.1, max = 0.9), nrow = 4)
+class(pool) <- c("pcadapt_pool", "matrix", "array")
+
+expect_s3_class(pcadapt(pool, K = 2), "pcadapt")
+
+# Frequency-matrix validation
+invalid.low <- pool
+invalid.low[1, 1] <- -0.1
+expect_error(pcadapt(invalid.low, K = 2), "between 0 and 1", fixed = TRUE)
+
+invalid.high <- pool
+invalid.high[1, 1] <- 1.1
+expect_error(pcadapt(invalid.high, K = 2), "between 0 and 1", fixed = TRUE)
+
+invalid.infinite <- pool
+invalid.infinite[1, 1] <- Inf
+expect_error(pcadapt(invalid.infinite, K = 2), "finite values", fixed = TRUE)
+
+invalid.nan <- pool
+invalid.nan[1, 1] <- NaN
+expect_error(pcadapt(invalid.nan, K = 2), "use NA instead", fixed = TRUE)
+
+missing.marker <- pool
+missing.marker[, 1] <- NA_real_
+expect_error(pcadapt(missing.marker, K = 2),
+             "marker must have at least one observed frequency", fixed = TRUE)
+
+missing.pool <- pool
+missing.pool[1, ] <- NA_real_
+expect_error(pcadapt(missing.pool, K = 2),
+             "pool must have at least one observed marker", fixed = TRUE)
+
+# Pool-seq argument validation
+expect_error(pcadapt(pool, K = 1.5), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(pool, K = c(1, 2)), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(pool, K = NA_real_), "one positive integer", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, method = "unknown"),
+             "mahalanobis", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, min.maf = NA_real_),
+             "one finite number", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, ploidy = 2),
+             "must be NULL", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, LD.clumping = list(size = 10, thr = 0.2)),
+             "not implemented", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, pca.only = NA),
+             "TRUE or FALSE", fixed = TRUE)
+
+# Rank is limited by centring and the retained marker count.
+three.pools <- pool[1:3, , drop = FALSE]
+class(three.pools) <- c("pcadapt_pool", "matrix", "array")
+expect_error(pcadapt(three.pools, K = 3), "K cannot exceed 2", fixed = TRUE)
+
+two.pools <- pool[1:2, , drop = FALSE]
+class(two.pools) <- c("pcadapt_pool", "matrix", "array")
+expect_error(pcadapt(two.pools, K = 2), "K cannot exceed 1", fixed = TRUE)
+
+no.markers <- pool
+no.markers[] <- 0
+expect_error(pcadapt(no.markers, K = 1), "No Pool-seq markers remain",
+             fixed = TRUE)
+
+# The MAF threshold is inclusive, as it is for genotype input.
+boundary <- matrix(
+  c(0, 0, 0.2, 0.2, rep(c(0.2, 0.4, 0.6, 0.8), 2)),
+  nrow = 4
+)
+class(boundary) <- c("pcadapt_pool", "matrix", "array")
+boundary.result <- pcadapt(boundary, K = 1, min.maf = 0.1)
+expect_true(1L %in% boundary.result$pass)
+
+################################################################################

--- a/tests/testthat/test_pool_validation.R
+++ b/tests/testthat/test_pool_validation.R
@@ -51,6 +51,10 @@ expect_error(pcadapt(pool, K = 2, LD.clumping = list(size = 10, thr = 0.2)),
              "not implemented", fixed = TRUE)
 expect_error(pcadapt(pool, K = 2, pca.only = NA),
              "TRUE or FALSE", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, pca.only = TRUE),
+             "not implemented", fixed = TRUE)
+expect_error(pcadapt(pool, K = 2, tol = 1e-4),
+             "not used for Pool-seq", fixed = TRUE)
 
 # Rank is limited by centring and the retained marker count.
 three.pools <- pool[1:3, , drop = FALSE]

--- a/vignettes/pcadapt.Rmd
+++ b/vignettes/pcadapt.Rmd
@@ -310,10 +310,16 @@ With Pool-Seq data, the package computes again a Mahalanobis distance based on P
 Computation of Mahalanobis distances is performed as follows
 
 ```{r,  eval = TRUE}
-res <- pcadapt(pool.data, K = 3)
+res <- pcadapt(pool.data, K = 2)
 summary(res)
 ```
-`res' is a list containing the same elements than when using individual genotype data.
+Because centring limits the rank of data from three pools to at most two,
+`K` cannot exceed 2 in this example. More generally, `K` cannot exceed the
+smaller of the number of pools minus one and the number of markers retained
+after MAF filtering.
+
+`res` is a list containing the same elements as an analysis of individual
+genotype data.
 
 A scree plot can be obtained and be possibly used to reduce `K`. If the number of populations `n` is too small, it is impossible to use the scree plot to choose `K` and the default value of $K=n-1$ should be used.
 


### PR DESCRIPTION
## Summary

This adds Pool-seq-specific input and argument validation and ensures that the
requested number of principal components is compatible with the rank of the
centred, MAF-filtered frequency matrix.

Previously, malformed frequency values and infeasible values of `K` could
reach the PCA implementation. This could produce misleading results, null
components, or low-level errors such as `subscript out of bounds`.

Arguments that are not implemented for Pool-seq data could also be supplied
and silently ignored.

## Changes

Pool-seq input must now:

- Be a numeric matrix.
- Contain pools in rows and markers in columns.
- Contain at least two pools and one marker.
- Use finite allele frequencies between zero and one.
- Use `NA`, rather than `NaN`, for missing frequencies.
- Include at least one observed frequency for every marker.
- Include at least one observed marker frequency for every pool.

The Pool-seq analysis now requires:

- `K` to be one positive integer.
- `method` to be `"mahalanobis"` or `"componentwise"`.
- `min.maf` to be one finite number between 0 and 0.45.
- `pca.only` to be either `TRUE` or `FALSE`.
- `ploidy` to remain `NULL`, because it is not used for frequency input.
- `LD.clumping` to remain `NULL`, because LD clumping is not implemented for
  Pool-seq input.

## Rank validation

Centring a matrix containing \(n\) pools limits its rank to at most \(n-1\).
After MAF filtering, the rank is also limited by the number of retained
markers.

The permitted value of `K` is therefore bounded by:

> **maximum K = min(number of pools − 1, number of retained markers)**

The function now checks this condition explicitly and reports the number of
pools and retained markers when the requested rank is infeasible.

For example:

- With three pools, `K` cannot exceed two.
- With two pools, `K` cannot exceed one.
- An analysis stops clearly when no markers remain after MAF filtering.

## MAF boundary

The Pool-seq pathway previously retained markers using:

```r
mean_freq > min.maf
```

whereas the genotype pathway uses an inclusive threshold. Pool-seq now also
uses:

```r
mean_freq >= min.maf
```

so a marker exactly at the documented threshold is handled consistently.

## Why this matters

Pool-seq matrices contain continuous allele-frequency estimates, not hard
genotype calls. They therefore need validation rules distinct from those used
for individual genotype matrices.

Explicit validation prevents out-of-range frequencies, empty pools, empty
markers, and rank-deficient component requests from entering the statistical
implementation. It also prevents users from believing that unsupported
ploidy or LD-clumping settings affected their Pool-seq analysis.

## Tests

Regression tests cover:

- Valid Pool-seq analysis.
- Frequencies below zero or above one.
- Infinite values and `NaN`.
- Entirely missing markers and pools.
- Fractional, vector-valued, and missing `K`.
- Unknown methods and missing MAF thresholds.
- Unsupported ploidy and LD-clumping arguments.
- Invalid `pca.only`.
- Rank limits for two and three pools.
- Removal of all markers.
- Inclusive MAF-threshold behaviour.

Validation results:

- `devtools::test()`: 57 passed, 0 failed.
- `R CMD check`: 0 errors, 0 warnings, 0 notes.