### PR TITLE
Use the actual rank-one SVD for two-pool data

### DIFF
--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -139,16 +139,8 @@ pcadapt.pcadapt_pool <- function(input,
 
   pass <- mean_freq > min.maf
   
-  if (nrow(input) == 2) {
-    obj.pca <- list(
-      u = matrix(NA_real_, nrow = 2, ncol = 1),
-      v = t(tmat[1, pass, drop = FALSE]),
-      d = 1
-    )
-  } else {
-    obj.pca <- svd(tmat[, pass, drop = FALSE])
-    #obj.pca <- RSpectra::svds(tmat[, pass, drop = FALSE], k = K)
-  }
+  obj.pca <- svd(tmat[, pass, drop = FALSE])
+  #obj.pca <- RSpectra::svds(tmat[, pass, drop = FALSE], k = K)
   
   w[pass, ] <- obj.pca$v[, 1:K, drop = FALSE]
   res <- get_statistics(w, method = method, pass = pass)

--- a/tests/testthat/test_pool_pca.R
+++ b/tests/testthat/test_pool_pca.R
@@ -1,0 +1,41 @@
+################################################################################
+
+context("POOLSEQ_PCA")
+
+################################################################################
+
+# The two-pool pathway is a rank-one PCA and should return genuine SVD scores
+# and loadings rather than placeholders.
+pool <- matrix(
+  c(
+    0.10, 0.20, 0.70, 0.80, 0.35, 0.65,
+    0.30, 0.40, 0.50, 0.60, 0.55, 0.45
+  ),
+  nrow = 2,
+  byrow = TRUE
+)
+class(pool) <- c("pcadapt_pool", "matrix", "array")
+
+result <- pcadapt(pool, K = 1, min.maf = 0)
+centred <- scale(unclass(pool), center = TRUE, scale = FALSE)
+expected <- svd(centred)
+
+expect_true(all(is.finite(result$scores)))
+expect_equal(abs(result$scores[, 1]), abs(expected$u[, 1]))
+expect_equal(abs(result$loadings[, 1]), abs(expected$v[, 1]))
+expect_equal(result$singular.values, 1)
+expect_equal(sum(result$loadings[, 1]^2), 1)
+
+# PCA signs are arbitrary, but scores and loadings must reconstruct the same
+# rank-one centred matrix when their signs are considered together.
+observed.reconstruction <-
+  result$scores[, 1, drop = FALSE] %*%
+  t(result$loadings[, 1, drop = FALSE]) * expected$d[1]
+expect_equal(
+  observed.reconstruction,
+  unname(centred),
+  tolerance = 1e-12,
+  check.attributes = FALSE
+)
+
+################################################################################


### PR DESCRIPTION
## Summary

This replaces the special two-pool shortcut with the same singular-value
decomposition used for other Pool-seq inputs.

With two pools, the centred frequency matrix has rank at most one, but it still
has a valid rank-one SVD. The previous implementation did not calculate that
SVD. Instead, it returned:

- An `NA` matrix for pool scores.
- The first row of the centred matrix as the marker loadings.
- A fixed singular value of `1`.

Consequently, the reported PCA scores were missing and the reported loadings
were not unit-normalized singular vectors.

## Changes

- Remove the special two-pool placeholder calculation.
- Use `svd()` for all Pool-seq matrices, including two-pool data.
- Add regression tests verifying that:
  - Pool scores are finite.
  - Scores match the left singular vector, up to arbitrary PCA sign.
  - Loadings match the right singular vector, up to sign.
  - Loadings have unit squared norm.
  - The rank-one scores and loadings reconstruct the centred frequency matrix.
  - The explained-variance proportion equals one.

## Statistical impact

For two pools, centring makes the second row the negative of the first, so the
matrix contains one nonzero component. The ordinary SVD therefore provides the
appropriate one-dimensional scores, loadings, and singular value without
requiring a special approximation.

The outlier p-values are effectively unchanged. The previous raw loadings
differ from the singular-vector loadings by a common scale factor, which is
cancelled by the genomic-inflation correction.

In the regression test, the maximum absolute difference between the old and
new p-values was:

> **2.2 × 10^-16**

This is floating-point rounding rather than a substantive statistical change.

The correction therefore repairs the reported PCA objects while preserving
the existing two-pool outlier inference.

## Validation

- `devtools::test()`: 44 passed, 0 failed.
- `R CMD check`: 0 errors, 0 warnings, 0 notes.

This change complements the Pool-seq input and rank validation in #105 but is
kept separate because it corrects the PCA calculation itself.