### PR TITLE
Stop when genomic inflation cannot be estimated

### DIFF
--- a/R/pcadapt.R
+++ b/R/pcadapt.R
@@ -34,6 +34,10 @@ NULL
 #' Pool-seq data, \code{pcadapt} provides p-values based on the Mahalanobis 
 #' distance for each SNP.
 #'
+#' The analysis stops if the genomic inflation factor is non-finite or not
+#' strictly positive. In that situation, calibrated chi-squared statistics and
+#' p-values cannot be defined reliably.
+#'
 #' @param input The output of function \code{read.pcadapt}.
 #' @param K an integer specifying the number of principal components to retain.
 #' @param method a character string specifying the method to be used to compute
@@ -190,6 +194,27 @@ pcadapt.pcadapt_pool <- function(input,
 #' 
 #' @keywords internal
 #'
+estimate_gif <- function(statistics, df, label) {
+  finite.statistics <- statistics[is.finite(statistics)]
+  if (length(finite.statistics) == 0L) {
+    stop(
+      "Cannot estimate the genomic inflation factor for ", label,
+      ": no finite test statistics are available.",
+      call. = FALSE
+    )
+  }
+
+  gif <- median(finite.statistics) / qchisq(0.5, df = df)
+  if (!is.finite(gif) || gif <= 0) {
+    stop(
+      "Cannot estimate the genomic inflation factor for ", label,
+      ": the median test statistic must be strictly positive.",
+      call. = FALSE
+    )
+  }
+  gif
+}
+
 get_statistics <- function(zscores, method, pass) {
   
   nSNP <- nrow(zscores)
@@ -201,7 +226,7 @@ get_statistics <- function(zscores, method, pass) {
     } else if (K > 1) {
       res[pass] <- bigutilsr::dist_ogk(zscores[pass, ])
     }
-    gif <- median(res, na.rm = TRUE) / qchisq(0.5, df = K)
+    gif <- estimate_gif(res, df = K, label = "Mahalanobis statistics")
     res.gif <- res / gif
     pval <- as.numeric(pchisq(res.gif, df = K, lower.tail = FALSE))
   } else if (method == "communality") {
@@ -213,7 +238,11 @@ get_statistics <- function(zscores, method, pass) {
   } else if (method == "componentwise") {
     res <- apply(zscores, MARGIN = 2, FUN = function(h) {h^2})
     gif <- sapply(1:K, FUN = function(h) {
-      median(zscores[, h]^2, na.rm = TRUE) / qchisq(0.5, df = 1)
+      estimate_gif(
+        zscores[, h]^2,
+        df = 1,
+        label = paste0("component ", h)
+      )
     })
     res.gif = res / gif
     pval <- NULL

--- a/man/pcadapt.Rd
+++ b/man/pcadapt.Rd
@@ -110,4 +110,8 @@ degrees of freedom. When using \code{method="componentwise"}, the z-scores
 should follow a chi-squared distribution with \code{1} degree of freedom. For 
 Pool-seq data, \code{pcadapt} provides p-values based on the Mahalanobis 
 distance for each SNP.
+
+The analysis stops if the genomic inflation factor is non-finite or not
+strictly positive. In that situation, calibrated chi-squared statistics and
+p-values cannot be defined reliably.
 }

--- a/tests/testthat/test_gif.R
+++ b/tests/testthat/test_gif.R
@@ -1,0 +1,55 @@
+context("genomic inflation factor")
+
+test_that("positive genomic inflation factors are retained", {
+  zscores <- matrix(c(-2, -1, 1, 2), ncol = 1)
+
+  mahalanobis <- pcadapt:::get_statistics(
+    zscores,
+    method = "mahalanobis",
+    pass = rep(TRUE, nrow(zscores))
+  )
+  componentwise <- pcadapt:::get_statistics(
+    zscores,
+    method = "componentwise",
+    pass = rep(TRUE, nrow(zscores))
+  )
+
+  expect_gt(mahalanobis$gif, 0)
+  expect_gt(componentwise$gif, 0)
+  expect_true(all(is.finite(mahalanobis$pvalues)))
+  expect_true(all(is.finite(componentwise$pvalues)))
+})
+
+test_that("zero genomic inflation factors stop the analysis", {
+  zscores <- matrix(1, nrow = 10, ncol = 1)
+
+  expect_error(
+    pcadapt:::get_statistics(
+      zscores,
+      method = "mahalanobis",
+      pass = rep(TRUE, nrow(zscores))
+    ),
+    "Mahalanobis statistics.*strictly positive"
+  )
+  expect_error(
+    pcadapt:::get_statistics(
+      matrix(0, nrow = 10, ncol = 2),
+      method = "componentwise",
+      pass = rep(TRUE, 10)
+    ),
+    "component 1.*strictly positive"
+  )
+})
+
+test_that("non-finite statistics stop the analysis", {
+  zscores <- matrix(NA_real_, nrow = 10, ncol = 1)
+
+  expect_error(
+    pcadapt:::get_statistics(
+      zscores,
+      method = "componentwise",
+      pass = rep(TRUE, nrow(zscores))
+    ),
+    "component 1.*no finite test statistics"
+  )
+})


### PR DESCRIPTION
## Summary

This PR validates the genomic inflation factor before using it to calibrate test statistics and p-values.

## Problem

`get_statistics()` estimates the genomic inflation factor from the median test statistic. If that median is zero, or if no finite statistics are available, the factor is zero or non-finite.

The current calculation then divides by that invalid value. This can silently produce `Inf`, `NaN`, or undefined p-values instead of explaining why the analysis cannot continue.

This situation can arise with retained markers that contain insufficient variation, degenerate component scores, or non-finite statistics.

## Changes

- Add a shared internal check for genomic inflation estimates.
- Stop when no finite test statistics are available.
- Stop when the estimated factor is zero, negative, or non-finite.
- Identify whether the failure occurred for Mahalanobis statistics or a specific component.
- Document why calibrated statistics and p-values cannot be reported in this situation.
- Add regression tests covering:
  - valid positive inflation factors;
  - zero Mahalanobis inflation;
  - zero componentwise inflation;
  - entirely non-finite componentwise statistics.

## Why stopping is preferable

A non-positive or non-finite genomic inflation factor does not define a valid calibration. Continuing would return numerical values that may look like analytical results but do not have the intended chi-squared interpretation.

A clear error lets users inspect marker variation, filtering, and the retained principal components before rerunning the analysis.

## Validation

- 45 tests passed.
- `R CMD check --no-manual`: 0 errors, 0 warnings, 0 notes when unavailable suggested packages were not forced.