### PR TITLE
Handle ties and missing values in get.pc()

### DIFF
--- a/R/pcadaptUtils.R
+++ b/R/pcadaptUtils.R
@@ -72,6 +72,9 @@ get.pop.names = function(pop){
 #'
 #' \code{get.pc} returns a data frame such that each row contains the index of
 #' the genetic marker and the principal component the most correlated with it.
+#' If several components have the same maximum squared z-score, the first one
+#' is returned. A missing value is returned only when all component z-scores
+#' are missing for a marker.
 #'
 #' @param x an object of class `pcadapt`. 
 #' @param list a list of integers corresponding to the indices of the markers of interest.
@@ -79,11 +82,19 @@ get.pop.names = function(pop){
 #' @export
 #'
 get.pc <- function(x, list) {
-  rem.na <- which(!is.na(x$zscores[list, 1]))
-  v <- vector(mode = "numeric", length = length(list))
-  v[rem.na] <- sapply(list[rem.na], FUN = function(h) {
-    which(x$zscores[h, ]^2 == max(x$zscores[h, ]^2, na.rm = TRUE))})
-  data.frame(SNP = list, PC = v)
+  if (length(list) == 0L) {
+    return(data.frame(SNP = list, PC = integer()))
+  }
+
+  squared.zscores <- x$zscores[list, , drop = FALSE]^2
+  pc <- apply(squared.zscores, MARGIN = 1, FUN = function(zscores) {
+    if (all(is.na(zscores))) {
+      return(NA_integer_)
+    }
+    which.max(zscores)
+  })
+
+  data.frame(SNP = list, PC = as.integer(pc))
 }
 
 ################################################################################

--- a/man/get.pc.Rd
+++ b/man/get.pc.Rd
@@ -14,4 +14,7 @@ get.pc(x, list)
 \description{
 \code{get.pc} returns a data frame such that each row contains the index of
 the genetic marker and the principal component the most correlated with it.
+If several components have the same maximum squared z-score, the first one
+is returned. A missing value is returned only when all component z-scores
+are missing for a marker.
 }

--- a/tests/testthat/test_get_pc.R
+++ b/tests/testthat/test_get_pc.R
@@ -1,0 +1,34 @@
+context("get.pc")
+
+test_that("get.pc returns one deterministic component per marker", {
+  x <- list(
+    zscores = rbind(
+      c(2, -2, 1),
+      c(NA, 3, 1),
+      c(NA, NA, NA),
+      c(1, 2, 3)
+    )
+  )
+
+  result <- get.pc(x, 1:4)
+
+  expect_identical(result$SNP, 1:4)
+  expect_identical(result$PC, c(1L, 2L, NA_integer_, 3L))
+})
+
+test_that("get.pc preserves marker order and duplicate indices", {
+  x <- list(zscores = rbind(c(1, 3), c(4, 2)))
+
+  result <- get.pc(x, c(2, 1, 2))
+
+  expect_identical(result$SNP, c(2, 1, 2))
+  expect_identical(result$PC, c(1L, 2L, 1L))
+})
+
+test_that("get.pc handles an empty marker selection", {
+  x <- list(zscores = matrix(numeric(), nrow = 0, ncol = 2))
+
+  result <- get.pc(x, integer())
+
+  expect_identical(result, data.frame(SNP = integer(), PC = integer()))
+})


### PR DESCRIPTION
## Summary

This PR makes `get.pc()` return exactly one deterministic principal component for every requested marker while handling missing component scores correctly.

## Problems

`get.pc()` identifies the most strongly associated principal component using:

```r
which(zscore^2 == max(zscore^2))
```

When two or more components have the same maximum squared z-score, `which()` returns multiple component indices. Assigning those indices into a single result position can cause recycling, truncation, warnings, or an output that is no longer aligned reliably with the requested markers.

Missingness is also currently determined from PC1 alone. Consequently, a marker is skipped when its PC1 z-score is missing even if another component has a valid score.

## Changes

- Return the first component when several components share the maximum squared z-score.
- Evaluate all components before classifying a marker as missing.
- Return `NA` only when every component score for that marker is missing.
- Preserve the order and duplication of requested marker indices.
- Return a correctly typed empty result for an empty marker selection.
- Document the tie-breaking and missing-value behaviour.
- Add regression tests for all these cases.

## Why deterministic tie handling is appropriate

`get.pc()` promises one principal component per marker. Returning the first maximum:

- fulfils that interface;
- follows the deterministic behaviour of `which.max()`;
- avoids silently expanding or recycling results;
- produces reproducible output;
- does not claim that one tied component is biologically more strongly associated than another.

The documented rule makes this limitation visible to users.

## Validation

- 43 package tests passed, including five new assertions.
- `R CMD check --no-manual`: 0 errors, 0 warnings, 0 notes when unavailable suggested packages were not forced.