### PR TITLE
Use an unambiguous missing-value sentinel in marker regressions

### DIFF
--- a/src/linear-regression.cpp
+++ b/src/linear-regression.cpp
@@ -27,7 +27,7 @@ NumericMatrix multLinReg(C macc,
     NumericVector z(K);              // all 0s
     for (size_t i = 0; i < n; i++) {
       x[i] = macc(i, j);
-      not_missing[i] = (x[i] != 3);
+      not_missing[i] = !NumericVector::is_na(x[i]);
       if (not_missing[i]) {
         for (k = 0; k < K; k++) {
           z[k] += u(i, k) * x[i]; 
@@ -71,11 +71,11 @@ NumericMatrix multLinReg(SEXP obj,        // af should be ALL allele frequencies
                          const NumericMatrix& u) {
   
   if (Rf_isMatrix(obj)) {
-    matAccScaled macc(obj, ind_col, af, ploidy, 3);
+    matAccScaled macc(obj, ind_col, af, ploidy, NA_REAL);
     return multLinReg(macc, u);
   } else {
     XPtr<bed> xpMat(obj);
-    bedAccScaled macc(xpMat, ind_col, af, ploidy, 3);
+    bedAccScaled macc(xpMat, ind_col, af, ploidy, NA_REAL);
     return multLinReg(macc, u);
   }
 }

--- a/tests/testthat/test_linear_regression.R
+++ b/tests/testthat/test_linear_regression.R
@@ -1,0 +1,63 @@
+context("linear regression")
+
+current_regression_reference <- function(genotypes, scores, ploidy = 2) {
+  observed <- !is.na(genotypes)
+  scores <- scores[observed, , drop = FALSE]
+  genotypes <- genotypes[observed]
+
+  allele.frequency <- sum(genotypes) / (ploidy * length(genotypes))
+  scaled.genotypes <-
+    (genotypes - ploidy * allele.frequency) /
+    sqrt(ploidy * allele.frequency * (1 - allele.frequency))
+
+  coefficients <- crossprod(scores, scaled.genotypes)
+  fitted <- scores %*% coefficients
+  residual.sum.squares <- sum((scaled.genotypes - fitted)^2)
+  residual.variance <-
+    residual.sum.squares / (length(genotypes) - ncol(scores))
+
+  drop(coefficients) /
+    sqrt(colSums(scores^2) * residual.variance)
+}
+
+test_that("observed standardized values equal to three are retained", {
+  genotypes <- c(2L, 2L, rep(0L, 9))
+  scores <- qr.Q(qr(cbind(seq_along(genotypes), seq_along(genotypes)^2)))
+  allele.frequency <- sum(genotypes) / (2 * length(genotypes))
+
+  expect_identical(allele.frequency, 2 / 11)
+  expect_identical(
+    (2 - 2 * allele.frequency) /
+      sqrt(2 * allele.frequency * (1 - allele.frequency)),
+    3
+  )
+
+  observed <- pcadapt:::multLinReg(
+    matrix(genotypes, ncol = 1),
+    1L,
+    allele.frequency,
+    2,
+    scores
+  )
+  expected <- current_regression_reference(genotypes, scores)
+
+  expect_equal(drop(observed), expected)
+})
+
+test_that("genuinely missing genotypes remain excluded", {
+  genotypes <- c(2L, NA_integer_, 1L, rep(0L, 8))
+  scores <- qr.Q(qr(cbind(seq_along(genotypes), seq_along(genotypes)^2)))
+  allele.frequency <- sum(genotypes, na.rm = TRUE) /
+    (2 * sum(!is.na(genotypes)))
+
+  observed <- pcadapt:::multLinReg(
+    matrix(genotypes, ncol = 1),
+    1L,
+    allele.frequency,
+    2,
+    scores
+  )
+  expected <- current_regression_reference(genotypes, scores)
+
+  expect_equal(drop(observed), expected)
+})


### PR DESCRIPTION
## Summary

This PR prevents legitimate standardized genotype values equal to `3` from being mistaken for missing genotypes during marker-level regression.

## Problem

`multLinReg()` currently constructs a scaled genotype accessor using `3` as its missing-value sentinel:

```cpp
matAccScaled macc(obj, ind_col, af, ploidy, 3);
```

It then detects missing observations with:

```cpp
not_missing[i] = (x[i] != 3);
```

However, `x[i]` is no longer a raw genotype. It is the centred and scaled genotype value:

```text
z = (g - ploidy × p) / sqrt(ploidy × p × (1 - p))
```

A legitimate observed genotype can therefore equal `3`.

For diploid data, an alternate homozygote at allele frequency `p = 2/11` gives exactly:

```text
(2 - 2 × 2/11) / sqrt(2 × 2/11 × 9/11) = 3
```

This frequency is realizable, for example, with four alternate alleles among 22 observed chromosomes.

The affected alternate homozygotes are consequently removed from the marker regression as though their genotypes were missing.

## Demonstrated effect

Using 11 diploid individuals with two observed alternate homozygotes and nine reference homozygotes gives an allele frequency of `2/11`.

In a controlled two-component example, the current sentinel collision changed the marker statistics from:

```text
Using all observed genotypes:
-0.636317, -2.119022
```

to:

```text
After legitimate values equal to 3 were treated as missing:
0.103821, 1.424499
```

Both component statistics changed substantially and reversed sign.

## Changes

- Represent missing scaled genotypes with R’s numerical missing value rather than the ordinary number `3`.
- Detect missing values using `NumericVector::is_na()`.
- Apply the correction to both matrix-backed and BED-backed genotype accessors.
- Preserve the existing marker-regression calculation otherwise.
- Add a regression test using the exactly realizable `p = 2/11` collision.
- Add a separate test confirming that genuinely missing genotypes remain excluded.

## Scope

This PR only corrects the ambiguous sentinel.

It does not change the statistical treatment of missing genotypes or resolve the separate question of whether marker-specific regression should use the full cross-product matrix of the observed PC scores.

## Validation

- 42 package tests passed.
- The package compiled successfully.
- `R CMD check --no-manual`: 0 errors, 0 warnings and 0 notes when unavailable suggested packages were not forced.